### PR TITLE
fix: 开发模式代理 /gallery-files，画廊配图不再显示为空

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 - 技术栈：React 19 + TypeScript + Vite 前端；Node.js 原生 `http` 服务端；`node:sqlite` / SQLite 数据库；Sharp 负责局部替换的图片解码、裁剪与合成；Electron 将同一套本地产品打包为桌面应用。
 - Node 版本要求：`>= 22.13.0`（依赖内置 `node:sqlite`）。
-- 开发：`npm run dev` 同时启动 Vite `127.0.0.1:5173` 和后端 `127.0.0.1:8788`；Vite 将 `/api`、`/files` 代理至后端。
+- 开发：`npm run dev` 同时启动 Vite `127.0.0.1:5173` 和后端 `127.0.0.1:8788`；Vite 将 `/api`、`/files`、`/gallery-files` 代理至后端；后端新增的顶层路径前缀必须同步加进 `vite.config.ts` 的 proxy，否则开发模式下会被 SPA fallback 回 `index.html`。
 - 生产：先 `npm run build`，再 `npm start`。后端从 `dist/` 托管前端，同时提供 API 和本地图片文件。
 - 桌面开发：`npm run desktop:dev` 先构建相同的前端，再由 Electron 启动本地服务和原生窗口；`npm run desktop:dist` 构建安装包。Electron 专属代码只在 `electron/main.cjs`，不得复制 `src/`、`server/` 或 `public/` 到另一个桌面项目。
 - CI 发布：推送 `v*` tag 触发 `.github/workflows/build.yml`，矩阵包含 Windows x64、macOS arm64 / x64、Ubuntu x64；各任务执行 `npm ci --cpu=<arch>` → `npm run build` → `electron-builder --<arch> --publish never`，按目标架构安装 Sharp 原生依赖。独立 release 任务发布非草稿 GitHub Release，三端均未签名。桌面服务位于资源目录 `app/server`，所需 Sharp、`@img`、`detect-libc`、`semver` 由 `extraResources` 放在同级 `app/node_modules`；新增或升级图像依赖时必须核对该运行时依赖清单，不能只依赖 `app.asar` 内的模块。

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ export default {
     proxy: {
       '/api': 'http://127.0.0.1:8788',
       '/files': 'http://127.0.0.1:8788',
+      // Gallery artwork is served from data/gallery, not dist/. Without this
+      // the SPA fallback answers every thumbnail with index.html.
+      '/gallery-files': 'http://127.0.0.1:8788',
     },
   },
 };


### PR DESCRIPTION
## 问题

`vite.config.ts` 只代理了 `/api` 和 `/files`：

```ts
proxy: {
  '/api': 'http://127.0.0.1:8788',
  '/files': 'http://127.0.0.1:8788',
},
```

但用户画廊条目的配图是后端从 `data/gallery/` 经 `/gallery-files/<file>` 提供的（`galleryDto()` 返回的就是这个路径）。这个前缀在开发模式下走不到后端，被 Vite 的 SPA fallback 接走，`<img>` 拿到的是 `index.html`：

```
$ curl -o /dev/null -w '%{http_code} %{content_type}\n' http://127.0.0.1:8788/gallery-files/<file>.png
200 image/png          ← 后端直连正常

$ curl -o /dev/null -w '%{http_code} %{content_type}\n' http://127.0.0.1:5173/gallery-files/<file>.png
200 text/html          ← 开发模式下画廊配图全部显示不出来
```

所以「我的收藏」里手动添加的配图、以及右键收藏进画廊的项目图片，在 `npm run dev` 下都是空白。`npm start` 和桌面版由后端同源托管，不受影响——这也是它容易被漏掉的原因。

## 改动

proxy 里补上 `/gallery-files`，并在 AGENTS.md 记下这条约束：后端新增顶层路径前缀时必须同步加进 proxy。

## 验证

`npm run dev` 下用隔离的 `LAYERIVE_DATA_ROOT` 建了一个带配图的「我的收藏」条目：

- 修复前：`200 text/html`，画廊里配图空白
- 修复后：`200 image/png`，238 bytes；浏览器里打开提示词画廊 →「我的收藏」，缩略图正常渲染（`naturalWidth: 64`）
- 回归：`/api/health` 仍返回 `application/json`，`/` 仍返回 SPA 的 `text/html`

`npm run lint` 通过。改动只涉及开发服务器配置，不影响构建产物和运行时行为。
